### PR TITLE
Fix YAML error in lint action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 on:
    push:
     branches: [ main ]
-  pull_request:
+   pull_request:
     branches: [ main ]
 jobs:
   golangci:


### PR DESCRIPTION
There was an indentation error in the YAML file controlling `golangci-lint` which was preventing it from being run; this PR fixes that.