### PR TITLE
Set 2m timeout for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,3 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout=2m


### PR DESCRIPTION
This PR is meant to fix lint runs [like this one](https://github.com/DangerOnTheRanger/celvet/runs/6355970511?check_suite_focus=true) by adding a 2 minute timeout to the linter presubmit. 