### PR TITLE
Use Kubernetes' fieldpath implementation

### DIFF
--- a/cost.go
+++ b/cost.go
@@ -73,7 +73,7 @@ func checkExprCost(schema *structuralschema.Structural, path *field.Path, nodeCo
 
 	switch schema.Type {
 	case "array":
-		itemCostErrors, itemCompileErrors := checkExprCost(schema.Items, path.Child("<items>"), nodeCostInfo.MultiplyByElementCost(schema))
+		itemCostErrors, itemCompileErrors := checkExprCost(schema.Items, path.Child("items"), nodeCostInfo.MultiplyByElementCost(schema))
 		compileErrors = append(compileErrors, itemCompileErrors...)
 		costErrors = append(costErrors, itemCostErrors...)
 	case "object":
@@ -85,7 +85,7 @@ func checkExprCost(schema *structuralschema.Structural, path *field.Path, nodeCo
 			costErrors = append(costErrors, propCostErrors...)
 		}
 		if schema.AdditionalProperties != nil && schema.AdditionalProperties.Structural != nil {
-			propCostErrors, propCompileErrors = checkExprCost(schema.AdditionalProperties.Structural, path.Child("<properties>"), nodeCostInfo.MultiplyByElementCost(schema))
+			propCostErrors, propCompileErrors = checkExprCost(schema.AdditionalProperties.Structural, path.Child("additionalProperties"), nodeCostInfo.MultiplyByElementCost(schema))
 			compileErrors = append(compileErrors, propCompileErrors...)
 			costErrors = append(costErrors, propCostErrors...)
 		}

--- a/cost.go
+++ b/cost.go
@@ -20,28 +20,27 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	schemacel "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // CostError represents an expression whose cost is beyond the per-expression
 // limit.
 type CostError struct {
 	// Path represents the path to the schema node containing the expression.
-	// The path-generating implementation here is different than the one
-	// in Kubernetes and will generate slightly different-looking output.
-	Path string
+	Path *field.Path
 	// Cost represents the cost of the expression. This is a unitless value.
 	Cost uint64
 }
 
 func (c *CostError) Error() string {
-	return fmt.Sprintf("expression at %q has cost of %d which exceeds cost limit of %d", c.Path, c.Cost, validation.StaticEstimatedCostLimit)
+	return fmt.Sprintf("expression at %q has cost of %d which exceeds cost limit of %d", c.Path.String(), c.Cost, validation.StaticEstimatedCostLimit)
 }
 
 // HumanReadableError returns an error message containing the amount by which
 // the expression exceeded the cost limit as a ratio.
 func (c *CostError) HumanReadableError() string {
 	exceedFactor := float64(c.Cost) / float64(validation.StaticEstimatedCostLimit)
-	return fmt.Sprintf("expression at %q exceeded budget by factor of %.1fx", c.Path, exceedFactor)
+	return fmt.Sprintf("expression at %q exceeded budget by factor of %.1fx", c.Path.String(), exceedFactor)
 
 }
 
@@ -49,11 +48,10 @@ func (c *CostError) HumanReadableError() string {
 // is greater than the per-expression cost limit. If any compilation errors
 // are encountered during this process, then those are returned as well.
 func CheckExprCost(schema *structuralschema.Structural) ([]*CostError, []error) {
-	// TODO(DangerOnTheRanger): swap this path system for field.Path
-	return checkExprCost(schema, "<root>", rootCostInfo())
+	return checkExprCost(schema, field.NewPath("openAPIV3Schema"), rootCostInfo())
 }
 
-func checkExprCost(schema *structuralschema.Structural, path string, nodeCostInfo costInfo) ([]*CostError, []error) {
+func checkExprCost(schema *structuralschema.Structural, path *field.Path, nodeCostInfo costInfo) ([]*CostError, []error) {
 	results, err := schemacel.Compile(schema, false, schemacel.PerCallLimit)
 	if err != nil {
 		return nil, []error{err}
@@ -75,19 +73,19 @@ func checkExprCost(schema *structuralschema.Structural, path string, nodeCostInf
 
 	switch schema.Type {
 	case "array":
-		itemCostErrors, itemCompileErrors := checkExprCost(schema.Items, path+".<items>", nodeCostInfo.MultiplyByElementCost(schema))
+		itemCostErrors, itemCompileErrors := checkExprCost(schema.Items, path.Child("<items>"), nodeCostInfo.MultiplyByElementCost(schema))
 		compileErrors = append(compileErrors, itemCompileErrors...)
 		costErrors = append(costErrors, itemCostErrors...)
 	case "object":
 		var propCompileErrors []error
 		var propCostErrors []*CostError
 		for propName, propSchema := range schema.Properties {
-			propCostErrors, propCompileErrors = checkExprCost(&propSchema, path+"."+propName, nodeCostInfo.MultiplyByElementCost(schema))
+			propCostErrors, propCompileErrors = checkExprCost(&propSchema, path.Child(propName), nodeCostInfo.MultiplyByElementCost(schema))
 			compileErrors = append(compileErrors, propCompileErrors...)
 			costErrors = append(costErrors, propCostErrors...)
 		}
 		if schema.AdditionalProperties != nil && schema.AdditionalProperties.Structural != nil {
-			propCostErrors, propCompileErrors = checkExprCost(schema.AdditionalProperties.Structural, path+"."+"<properties>", nodeCostInfo.MultiplyByElementCost(schema))
+			propCostErrors, propCompileErrors = checkExprCost(schema.AdditionalProperties.Structural, path.Child("<properties>"), nodeCostInfo.MultiplyByElementCost(schema))
 			compileErrors = append(compileErrors, propCompileErrors...)
 			costErrors = append(costErrors, propCostErrors...)
 		}

--- a/cost_test.go
+++ b/cost_test.go
@@ -98,7 +98,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("array", genArraySchema(nil, withRule(genStringSchema(nil), `self == self`))),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "array", "<items>"),
+					Path: field.NewPath("openAPIV3Schema", "array", "items"),
 					Cost: 329855795200,
 				},
 			},
@@ -128,7 +128,7 @@ func TestCost(t *testing.T) {
 			schema: genMapSchema(nil, withRule(genStringSchema(nil), `self == self`)),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "<properties>"),
+					Path: field.NewPath("openAPIV3Schema", "additionalProperties"),
 					Cost: 329855795200,
 				},
 			},
@@ -159,7 +159,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("mapWithArray", genMapSchema(nil, genArraySchema(nil, withRule(genStringSchema(nil), `self == self`)))),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "mapWithArray", "<properties>", "<items>"),
+					Path: field.NewPath("openAPIV3Schema", "mapWithArray", "additionalProperties", "items"),
 					Cost: 329855795200,
 				},
 			},

--- a/cost_test.go
+++ b/cost_test.go
@@ -88,7 +88,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("array", withRule(genArraySchema(nil, genStringSchema(nil)), `self.all(x, x == x)`)),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "array"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "properties").Key("array").Child("x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 329858626352,
 				},
 			},
@@ -98,7 +98,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("array", genArraySchema(nil, withRule(genStringSchema(nil), `self == self`))),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "array", "items"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "properties").Key("array").Child("items", "x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 329855795200,
 				},
 			},
@@ -113,7 +113,7 @@ func TestCost(t *testing.T) {
 			schema: withRule(genMapSchema(nil, genStringSchema(nil)), `self.all(x, self.all(y, x == y))`),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 773092147202,
 				},
 			},
@@ -128,7 +128,7 @@ func TestCost(t *testing.T) {
 			schema: genMapSchema(nil, withRule(genStringSchema(nil), `self == self`)),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "additionalProperties"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "additionalProperties", "x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 329855795200,
 				},
 			},
@@ -139,7 +139,7 @@ func TestCost(t *testing.T) {
 				`["abc", "def", "ghi", "jhk"].all(x, ["abc", "def", "ghi", "jhk"].all(y, x == self && y == self && x == y))`)),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "excessiveString"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "properties").Key("excessiveString").Child("x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 15099715,
 				},
 			},
@@ -159,7 +159,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("mapWithArray", genMapSchema(nil, genArraySchema(nil, withRule(genStringSchema(nil), `self == self`)))),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "mapWithArray", "additionalProperties", "items"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "properties").Key("mapWithArray").Child("additionalProperties", "items", "x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 329855795200,
 				},
 			},
@@ -169,7 +169,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("multiRuleArray", withRule(genArraySchema(nil, withRule(genStringSchema(nil), `true`)), `self.all(x, self.all(y, x == y))`)),
 			expectedErrors: []*CostError{
 				{
-					Path: field.NewPath("openAPIV3Schema", "multiRuleArray"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "properties").Key("multiRuleArray").Child("x-kubernetes-validations").Index(0).Child("rule"),
 					Cost: 345881509130194127,
 				},
 			},

--- a/cost_test.go
+++ b/cost_test.go
@@ -18,6 +18,7 @@ import (
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func genStringSchema(maxLength *int64) *structuralschema.Structural {
@@ -87,7 +88,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("array", withRule(genArraySchema(nil, genStringSchema(nil)), `self.all(x, x == x)`)),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.array",
+					Path: field.NewPath("openAPIV3Schema", "array"),
 					Cost: 329858626352,
 				},
 			},
@@ -97,7 +98,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("array", genArraySchema(nil, withRule(genStringSchema(nil), `self == self`))),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.array.<items>",
+					Path: field.NewPath("openAPIV3Schema", "array", "<items>"),
 					Cost: 329855795200,
 				},
 			},
@@ -112,7 +113,7 @@ func TestCost(t *testing.T) {
 			schema: withRule(genMapSchema(nil, genStringSchema(nil)), `self.all(x, self.all(y, x == y))`),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>",
+					Path: field.NewPath("openAPIV3Schema"),
 					Cost: 773092147202,
 				},
 			},
@@ -127,7 +128,7 @@ func TestCost(t *testing.T) {
 			schema: genMapSchema(nil, withRule(genStringSchema(nil), `self == self`)),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.<properties>",
+					Path: field.NewPath("openAPIV3Schema", "<properties>"),
 					Cost: 329855795200,
 				},
 			},
@@ -138,7 +139,7 @@ func TestCost(t *testing.T) {
 				`["abc", "def", "ghi", "jhk"].all(x, ["abc", "def", "ghi", "jhk"].all(y, x == self && y == self && x == y))`)),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.excessiveString",
+					Path: field.NewPath("openAPIV3Schema", "excessiveString"),
 					Cost: 15099715,
 				},
 			},
@@ -158,7 +159,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("mapWithArray", genMapSchema(nil, genArraySchema(nil, withRule(genStringSchema(nil), `self == self`)))),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.mapWithArray.<properties>.<items>",
+					Path: field.NewPath("openAPIV3Schema", "mapWithArray", "<properties>", "<items>"),
 					Cost: 329855795200,
 				},
 			},
@@ -168,7 +169,7 @@ func TestCost(t *testing.T) {
 			schema: genRootSchema("multiRuleArray", withRule(genArraySchema(nil, withRule(genStringSchema(nil), `true`)), `self.all(x, self.all(y, x == y))`)),
 			expectedErrors: []*CostError{
 				{
-					Path: "<root>.multiRuleArray",
+					Path: field.NewPath("openAPIV3Schema", "multiRuleArray"),
 					Cost: 345881509130194127,
 				},
 			},
@@ -194,7 +195,7 @@ func TestCost(t *testing.T) {
 }
 
 func errorsEqual(x, y *CostError) bool {
-	return x.Path == y.Path && x.Cost == y.Cost
+	return x.Path.String() == y.Path.String() && x.Cost == y.Cost
 }
 
 func int64ptr(i int64) *int64 {

--- a/limits.go
+++ b/limits.go
@@ -59,7 +59,7 @@ func (l *LimitError) Error() string {
 // for every missing limit that could be set on a list/map/string belonging
 // to that schema or any level beneath it.
 func CheckMaxLimits(schema *structuralschema.Structural) []*LimitError {
-	return checkMaxLimits(schema, field.NewPath("openAPIV3Schema"))
+	return checkMaxLimits(schema, field.NewPath("spec", "validation", "openAPIV3Schema"))
 }
 
 func checkMaxLimits(schema *structuralschema.Structural, path *field.Path) []*LimitError {
@@ -88,7 +88,7 @@ func checkMaxLimits(schema *structuralschema.Structural, path *field.Path) []*Li
 			limitErrors = append(limitErrors, checkMaxLimits(schema.AdditionalProperties.Structural, path.Child("additionalProperties"))...)
 		}
 		for propName, propSchema := range schema.Properties {
-			limitErrors = append(limitErrors, checkMaxLimits(&propSchema, path.Child(propName))...)
+			limitErrors = append(limitErrors, checkMaxLimits(&propSchema, path.Child("properties").Key(propName))...)
 		}
 	}
 	return limitErrors

--- a/limits.go
+++ b/limits.go
@@ -71,7 +71,7 @@ func checkMaxLimits(schema *structuralschema.Structural, path *field.Path) []*Li
 		} else if schema.ValueValidation.MaxItems == nil {
 			limitErrors = append(limitErrors, &LimitError{path, SchemaTypeList})
 		}
-		limitErrors = append(limitErrors, checkMaxLimits(schema.Items, path.Child("<items>"))...)
+		limitErrors = append(limitErrors, checkMaxLimits(schema.Items, path.Child("items"))...)
 	case "string":
 		if schema.ValueValidation == nil {
 			limitErrors = append(limitErrors, &LimitError{path, SchemaTypeString})
@@ -85,7 +85,7 @@ func checkMaxLimits(schema *structuralschema.Structural, path *field.Path) []*Li
 			} else if schema.ValueValidation.MaxProperties == nil {
 				limitErrors = append(limitErrors, &LimitError{path, SchemaTypeMap})
 			}
-			limitErrors = append(limitErrors, checkMaxLimits(schema.AdditionalProperties.Structural, path)...)
+			limitErrors = append(limitErrors, checkMaxLimits(schema.AdditionalProperties.Structural, path.Child("additionalProperties"))...)
 		}
 		for propName, propSchema := range schema.Properties {
 			limitErrors = append(limitErrors, checkMaxLimits(&propSchema, path.Child(propName))...)

--- a/limits_test.go
+++ b/limits_test.go
@@ -16,15 +16,15 @@ package celvet
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestMaxLimits(t *testing.T) {
 	tests := []struct {
 		name           string
 		schema         *structuralschema.Structural
-		expectedErrors []*limitError
+		expectedErrors []*LimitError
 	}{
 		{
 			name: "integer",
@@ -33,7 +33,7 @@ func TestMaxLimits(t *testing.T) {
 					Type: "integer",
 				},
 			},
-			expectedErrors: make([]*limitError, 0),
+			expectedErrors: make([]*LimitError, 0),
 		},
 		{
 			name: "missing array limit",
@@ -47,10 +47,10 @@ func TestMaxLimits(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []*limitError{
+			expectedErrors: []*LimitError{
 				{
-					Name: "<root>",
-					Type: typeList,
+					Path: field.NewPath("openAPIV3Schema"),
+					Type: SchemaTypeList,
 				},
 			},
 		},
@@ -68,10 +68,10 @@ func TestMaxLimits(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []*limitError{
+			expectedErrors: []*LimitError{
 				{
-					Name: "<root>",
-					Type: typeMap,
+					Path: field.NewPath("openAPIV3Schema"),
+					Type: SchemaTypeMap,
 				},
 			},
 		},
@@ -82,10 +82,10 @@ func TestMaxLimits(t *testing.T) {
 					Type: "string",
 				},
 			},
-			expectedErrors: []*limitError{
+			expectedErrors: []*LimitError{
 				{
-					Name: "<root>",
-					Type: typeString,
+					Path: field.NewPath("openAPIV3Schema"),
+					Type: SchemaTypeString,
 				},
 			},
 		},
@@ -103,14 +103,14 @@ func TestMaxLimits(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []*limitError{
+			expectedErrors: []*LimitError{
 				{
-					Name: "<root>",
-					Type: typeMap,
+					Path: field.NewPath("openAPIV3Schema"),
+					Type: SchemaTypeMap,
 				},
 				{
-					Name: "<root>",
-					Type: typeString,
+					Path: field.NewPath("openAPIV3Schema"),
+					Type: SchemaTypeString,
 				},
 			},
 		},
@@ -123,10 +123,14 @@ func TestMaxLimits(t *testing.T) {
 			}
 			for i, seenError := range errors {
 				expectedError := test.expectedErrors[i]
-				if !cmp.Equal(seenError, expectedError) {
+				if !limitErrorsEqual(seenError, expectedError) {
 					t.Errorf("Wrong error (expected %v, got %v)", expectedError, seenError)
 				}
 			}
 		})
 	}
+}
+
+func limitErrorsEqual(x, y *LimitError) bool {
+	return x.Path.String() == y.Path.String() && x.Type == y.Type
 }

--- a/limits_test.go
+++ b/limits_test.go
@@ -49,7 +49,7 @@ func TestMaxLimits(t *testing.T) {
 			},
 			expectedErrors: []*LimitError{
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema"),
 					Type: SchemaTypeList,
 				},
 			},
@@ -70,7 +70,7 @@ func TestMaxLimits(t *testing.T) {
 			},
 			expectedErrors: []*LimitError{
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema"),
 					Type: SchemaTypeMap,
 				},
 			},
@@ -84,7 +84,7 @@ func TestMaxLimits(t *testing.T) {
 			},
 			expectedErrors: []*LimitError{
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema"),
 					Type: SchemaTypeString,
 				},
 			},
@@ -105,11 +105,11 @@ func TestMaxLimits(t *testing.T) {
 			},
 			expectedErrors: []*LimitError{
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema"),
 					Type: SchemaTypeMap,
 				},
 				{
-					Path: field.NewPath("openAPIV3Schema", "additionalProperties"),
+					Path: field.NewPath("spec", "validation", "openAPIV3Schema", "additionalProperties"),
 					Type: SchemaTypeString,
 				},
 			},

--- a/limits_test.go
+++ b/limits_test.go
@@ -109,7 +109,7 @@ func TestMaxLimits(t *testing.T) {
 					Type: SchemaTypeMap,
 				},
 				{
-					Path: field.NewPath("openAPIV3Schema"),
+					Path: field.NewPath("openAPIV3Schema", "additionalProperties"),
 					Type: SchemaTypeString,
 				},
 			},


### PR DESCRIPTION
This PR removes the internal path implementation and replaces it with the one from Kubernetes, so paths seen from k8s logging/error messages should be completely equivalent with ones seen from celvet, and vice-versa.