### PR TITLE
Enable revive when running golangci-lint presubmit

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=2m
+          args: --timeout=2m -E revive

--- a/cost.go
+++ b/cost.go
@@ -120,7 +120,7 @@ func multiplyWithOverflowGuard(baseCost, cardinality uint64) uint64 {
 }
 
 // unbounded uses nil to represent an unbounded cardinality value.
-var unbounded *uint64 = nil
+var unbounded *uint64
 
 type costInfo struct {
 	// MaxCardinality represents a limit to the number of data elements that can exist for the current


### PR DESCRIPTION
This PR enables the [revive](https://github.com/mgechev/revive) linter when running golangci-lint. The [default list](https://golangci-lint.run/usage/linters/) of linters used by golangci-lint (which is what celvet currently uses) will miss things like missing comments on exported symbols, and adding revive should catch those kinds of things.